### PR TITLE
Rom startup/copyover fix

### DIFF
--- a/area/startup
+++ b/area/startup
@@ -24,8 +24,7 @@ while ( 1 )
     end
 
     # Run rom.
-    ../src/rom $port >&! $logfile
-
+    ../area/rom $port >&! $logfile
 
     # Restart, giving old connections a chance to die.
     if ( -e shutdown.txt ) then

--- a/src/act_wiz.c
+++ b/src/act_wiz.c
@@ -4488,8 +4488,7 @@ void do_prefix (CHAR_DATA * ch, char *argument)
 #define COPYOVER_FILE "copyover.data"
 
 /* This is the executable file */
-#define EXE_FILE      "../src/rom"
-
+#define EXE_FILE      "../area/rom"
 
 /*  Copyover - Original idea: Fusion of MUD++
  *  Adapted to Diku by Erwin S. Andreasen, <erwin@pip.dknet.dk>


### PR DESCRIPTION
- The startup was pointing to ../src/rom instead of ../area/rom where the Makefile was building to. 
- Updated act_wiz.c to fix do_copyover.  do_copyover was failing due to looking for the executable in the src directory also.  Changed the define EXE_FILE to point to ../area/rom and then it successfully was able to copyover.

Tried to send you an email but it bounced back ;-)  Was excited to see QuickMUD/FastROM on GitHub.
