### PR TITLE
do_copyover bug fix to alleviate long running QuickMUD bug that allow…

### DIFF
--- a/src/act_wiz.c
+++ b/src/act_wiz.c
@@ -4526,7 +4526,7 @@ void do_copyover (CHAR_DATA * ch, char *argument)
         CHAR_DATA *och = CH (d);
         d_next = d->next;        /* We delete from the list , so need to save this */
 
-        if (!d->character || d->connected > CON_PLAYING)
+        if (!d->character || d->connected < CON_PLAYING)
         {                        /* drop those logging on */
             write_to_descriptor (d->descriptor,
                                  "\n\rSorry, we are rebooting. Come back in a few minutes.\n\r",


### PR DESCRIPTION
While making updates to a ROM off shoot I was working on I realized there's kind of a nasty bug in do_copyover.  Whoever made QuickMUD added more CON_ states with many of them being negative values which isn't how stock rom was.  A consequence of this is that do_copyover was using the values to check for state as to whether to disconnect someone.

Basically, people creating characters or at the login prompt weren't getting disconnected.  This means if you were creating a character you'd be brought back into the game at level 0 on copyover (and then would crash the mud on leveling or killing a mob but would be fixed to level 1 on next real login).  The worse bug is if you typed in a player name at login and then just sat and waited on the password prompt you would be logged in as that user (without entering a password) on copyover.

Simply changing the > to < check fixes the bug.
